### PR TITLE
feat: add `become: true`

### DIFF
--- a/infra/playbook.yml
+++ b/infra/playbook.yml
@@ -285,7 +285,7 @@
                 (tool_versions_raw.content | b64decode).splitlines()
                 | map('trim')
                 | reject('match', '^(#|$)')
-                | map(attribute='split')
+                | map('regex_findall', '(\S+)')
                 | list
               }}
 


### PR DESCRIPTION
## 基本情報
プルリクエスト番号: #8
タイトル: feat: add become: true
ブランチ: fix/insufficient-permissions-to-install-error-on-password-sudo → main
作成者: [argon-dev22](https://github.com/argon-dev22)
作成日: 2025年8月25日
ステータス: Draft（レビュー準備中）
コミット数: 6件
変更: +28 −1

## 解決する問題
このPRは[Issue #7](https://github.com/argon-dev22/environments/issues/7)を解決します：

### 問題の詳細
TASK [Install Homebrew] ****************************************************
fatal: [localhost]: FAILED! => {
  "msg": "non-zero return code", 
  "rc": 1, 
  "stderr": "Insufficient permissions to install Homebrew to \"/home/linuxbrew/.linuxbrew\""
}
根本原因: sudoパスワードが設定されている環境で、AnsibleがHomebrewインストール時に権限昇格できていない

## 実装された修正
1. メインの修正: become: yesの追加
Homebrewインストールタスクに管理者権限を付与：

Copy- name: Install Homebrew
  shell: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
  become: yes  # ← 追加
  when: brew_check.rc != 0
2. ディレクトリ作成タスクの追加
Linux環境でのHomebrew用ディレクトリの事前作成：

Copy- name: Prepare Homebrew installation directories (Linux)
  block:
    - name: Create /home/linuxbrew directory
      file:
        path: /home/linuxbrew
        state: directory
        mode: '0755'
        owner: "{{ ansible_user_id }}"
        group: "{{ ansible_user_id }}"
      become: yes
    
    - name: Create /home/linuxbrew/.linuxbrew directory
      file:
        path: /home/linuxbrew/.linuxbrew
        state: directory
        mode: '0755'
        owner: "{{ ansible_user_id }}"
        group: "{{ ansible_user_id }}"
      become: yes
  when:
    - brew_check.rc != 0
    - ansible_facts.os_family == "Debian"

## コミット履歴と修正経緯

### コミット一覧
[cb86117](https://github.com/argon-dev22/environments/pull/8/commits/cb861170de7e859c7bdb9d6637340f49006de1e4): feat: add become: true
[dca87a6](https://github.com/argon-dev22/environments/pull/8/commits/dca87a6e0a25022f7efea392f1b13935bbe96ad8): fix: update playbook.yml
[040771f](https://github.com/argon-dev22/environments/pull/8/commits/040771fc438350b3306bad361fca02b978390cb6): fix: Update playbook.yml
[b00f794](https://github.com/argon-dev22/environments/pull/8/commits/b00f79480b4cf626e69cf97f941aa5b6587e5bef): fix: remove unsupported decode filter from .tool-versions parsing
[842e7ed](https://github.com/argon-dev22/environments/pull/8/commits/842e7edf729fa3cb6a367408e3c5454f77ad6ab3): fix: use split method via attribute mapping for .tool-versions parsing
[9487b8d](https://github.com/argon-dev22/environments/pull/8/commits/9487b8d2eb680712bef6ad1ef056935f78e008c7): fix: use regex_findall with capture groups for .tool-versions parsing

### 修正の進化過程
Phase 1: 権限問題の解決
become: trueの追加でsudo権限を有効化
Phase 2: .tool-versionsファイル解析の修正
複数回の反復修正を経て、Ansibleの異なるバージョンとの互換性を確保：

decodeフィルター問題:

問題: Ansibleの古いバージョンで'decode'フィルターが未サポート
解決: b64decodeフィルターのみ使用（自動UTF-8デコード）
splitメソッド問題:

問題: Jinja2環境でsplitフィルターが未登録
解決: map('split')をmap(attribute='split')に変更
最終解決:

問題: map(attribute='split')がメソッド参照を返しループ処理が失敗
解決: regex_findall('(\S+)')で各行を空白区切りの配列に正確に分割